### PR TITLE
in `qgraph::qgraph()` `edge_color`  should be `edge.color`

### DIFF
--- a/R/PlottingFunctions.R
+++ b/R/PlottingFunctions.R
@@ -200,7 +200,7 @@ if(!any(class(output) == "easybgm")){
       diag(graph_inc) <- 1
       colnames(graph_inc) <- colnames(output$parameters)
       qgraph::qgraph(graph_inc,
-                     edge_color = graph_color,
+                     edge.color = graph_color,
                      layout = args$layout_avg,# specifies the color of the edges
                      theme = args$theme,
                      vsize = args$vsize,


### PR DESCRIPTION
I could have opened an issue but this seemed a bit too trivial for that.

Currently, you get this warning
```r
library(easybgm)
library(bgms)
data <- Wenchuan
fit2 <- easybgm(data, type = "ordinal",
                iter = 1000, save = TRUE,
                centrality = TRUE)

rr <- plot_edgeevidence(fit2, split = TRUE)
Warning message:
In qgraph::qgraph(graph_inc, edge_color = graph_color, layout = args$layout_avg,  :
  The following arguments are not documented and likely not arguments of qgraph and thus ignored: edge_color
```
after this PR not anymore.