### PR TITLE
Fixed bug with edge inclusion probability (for Beta-Bern prior)

### DIFF
--- a/R/functions.bgms.R
+++ b/R/functions.bgms.R
@@ -51,6 +51,9 @@ bgm_extract.package_bgms <- function(fit, type, save,
     edge.prior <- calculate_edge_prior(alpha = args$beta_bernoulli_alpha,
                                        beta = args$beta_bernoulli_beta,
                                        p = ncol(data))
+    
+    # otherwise it saves the wrong values (could be done more elegantly)
+    args$inclusion_probability <- edge.prior
   }
   
   bgms_res <- list()


### PR DESCRIPTION
There were problems calculating the prior inclusion probabilities when the edge prior was "beta-Bernoulli", resulting in incorrect Bayes factors. I slightly changed the calculate_edge_prior function and the beta_bernoulli_prob function to use logarithmic calculations to fix the overflow and precision issues that caused this problem. I also added another line of code to the bgm_extract.package_bgms function so that these calculated prior probabilities are properly stored in fit_arguments. 