### PR TITLE
Update: Change in the calculation of prior inclusion probabilities and an update in the documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ BugReports: https://github.com/KarolineHuth/easybgm/issues
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Imports: 
     BDgraph,
     BGGM,

--- a/R/AuxiliaryFunctions.R
+++ b/R/AuxiliaryFunctions.R
@@ -349,29 +349,15 @@ beta_bernoulli_prob <- function(c, alpha, beta, p) {
   return(log_prob)
 }
 
-# Calculates the probability of an edge being present in the beta-bernoulli prior of the bgms package
-# Returns the probability for an (every) individual edge to be present
-# @args alpha, beta arguments of beta bernoulli prior, p number of nodes
-calculate_edge_prior <- function(alpha, beta, p) {
-  
-  k <- p * (p - 1) / 2
-  log_prob <- -Inf  # Initialize log-sum
-  
-  for (c in 0:k) {
-    log_pr <- beta_bernoulli_prob(c, alpha, beta, p)
-    log_weighted_pr <- log_pr + log(c / k)
-    
-    log_prob <- log_sum_exp(log_prob, log_weighted_pr)
-  }
-  
-  return(exp(log_prob))  # Convert back from log to probability
-}
+# Calculates the probability of an edge being present in the beta-bernoulli (BB) 
+# or the stochastic block prior on the network structure of the bgms package
+# Returns the prior inclusion probability for individual edges
+# which simply calculates the expected value of the BB distribution 
+# @args alpha, beta arguments of beta bernoulli prior, 
 
 
-# Helper function for log-sum-exp to avoid precision issues
-log_sum_exp <- function(log_a, log_b) {
-  if (log_a == -Inf) return(log_b)  # Handle cases where one term is -Inf
-  if (log_b == -Inf) return(log_a)
-  return(log_a + log(1 + exp(log_b - log_a)))  # Log-sum-exp trick
+calculate_edge_prior <- function(alpha, beta) {
+   alpha / (alpha + beta)
 }
+
 

--- a/R/easybgm.R
+++ b/R/easybgm.R
@@ -63,15 +63,36 @@
 #'
 #' \itemize{
 #'
-#' \item \code{interaction_prior} prior distribution of the interaction parameters, can be either "UnitInfo" for the Unit Information prior, or "Cauchy" for the Cauchy distribution. The default is set to "UnitInfo".
+#' \item \code{interaction_scale} the scale of the Cauchy distribution that is used as a
+#' prior for the pairwise interaction parameters. The default is 2.5.
 #'
-#' \item \code{edge_prior} prior on the graph structure, which can be either "Bernoulli" or "Beta-Bernoulli". The default is "Bernoulli".
+#' \item \code{edge_prior} prior on the graph structure, which can be either "Bernoulli", "Beta-Bernoulli" or "Stochastic Block". The default is "Bernoulli".
 #'
-#' \item \code{inclusion_prior} prior edge inclusion probability for the "Bernoulli" distribution. The default is 0.5.
+#' \item \code{inclusion_probability} prior edge inclusion probability for the "Bernoulli" distribution. The default is 0.5.
 #'
-#' \item \code{beta_bernoulli_alpha} and \code{beta_bernoulli_alpha} the parameters of the "Beta-Bernoulli" distribution. The default is 1 for both.
+#' \item \code{beta_bernoulli_alpha} and \code{beta_bernoulli_alpha} the parameters of the "Beta-Bernoulli" or "Stochastic Block" priors. The default is 1 for both.
+#' 
+#' \item \code{dirichlet_alpha} The shape of the Dirichlet prior on the node-to-block
+#' allocation parameters for the Stochastic Block prior on the graph structure.
 #'
 #' \item \code{threshold_alpha} and \code{threshold_beta} the parameters of the beta-prime distribution for the threshold parameters. The defaults are both set to 1.
+#'
+#' \item \code{variable_type} What kind of variables are there in \code{x}? Can be a
+#' single character string specifying the variable type of all \code{p}
+#' variables at once or a vector of character strings of length \code{p}
+#' specifying the type for each variable in \code{x} separately. Currently, bgm
+#' supports ``ordinal'' and ``blume-capel''. Binary variables are automatically
+#' treated as ``ordinal’’. Defaults to \code{variable_type = "ordinal"}.
+#'
+#'  \item \code{reference_category} he reference category in the Blume-Capel model.
+#' Should be an integer within the range of integer scores observed for the
+#' 'blume-capel' variable. Can be a single number specifying the reference
+#' category for all Blume-Capel variables at once, or a vector of length
+#' \code{p} where the \code{i}-th element contains the reference category for
+#' variable \code{i} if it is Blume-Capel, and bgm ignores its elements for
+#' other variable types. The value of the reference category is also recoded
+#' when bgm recodes the corresponding observations. Only required if there is at
+#' least one variable of type ``blume-capel''.
 #'
 #' }
 #'

--- a/R/functions.bgms.R
+++ b/R/functions.bgms.R
@@ -47,10 +47,9 @@ bgm_extract.package_bgms <- function(fit, type, save,
   
   if (args$edge_prior[1] == "Bernoulli") {
     edge.prior <- args$inclusion_probability
-  } else {
+  } else { # if BB or SBM
     edge.prior <- calculate_edge_prior(alpha = args$beta_bernoulli_alpha,
-                                       beta = args$beta_bernoulli_beta,
-                                       p = ncol(data))
+                                       beta = args$beta_bernoulli_beta)
     
     # otherwise it saves the wrong values (could be done more elegantly)
     args$inclusion_probability <- edge.prior

--- a/R/functions.bgms.R
+++ b/R/functions.bgms.R
@@ -51,6 +51,9 @@ bgm_extract.package_bgms <- function(fit, type, save,
     edge.prior <- calculate_edge_prior(alpha = args$beta_bernoulli_alpha,
                                        beta = args$beta_bernoulli_beta,
                                        p = ncol(data))
+    
+    # otherwise it saves the wrong values (could be done more elegantly)
+    args$inclusion_probability <- edge.prior
   }
   
   bgms_res <- list()

--- a/man/easybgm.Rd
+++ b/man/easybgm.Rd
@@ -87,15 +87,36 @@ arguments. We give an overview of the prior arguments per package below.
 
 \itemize{
 
-\item \code{interaction_prior} prior distribution of the interaction parameters, can be either "UnitInfo" for the Unit Information prior, or "Cauchy" for the Cauchy distribution. The default is set to "UnitInfo".
+\item \code{interaction_scale} the scale of the Cauchy distribution that is used as a
+prior for the pairwise interaction parameters. The default is 2.5.
 
-\item \code{edge_prior} prior on the graph structure, which can be either "Bernoulli" or "Beta-Bernoulli". The default is "Bernoulli".
+\item \code{edge_prior} prior on the graph structure, which can be either "Bernoulli", "Beta-Bernoulli" or "Stochastic Block". The default is "Bernoulli".
 
 \item \code{inclusion_prior} prior edge inclusion probability for the "Bernoulli" distribution. The default is 0.5.
 
-\item \code{beta_bernoulli_alpha} and \code{beta_bernoulli_alpha} the parameters of the "Beta-Bernoulli" distribution. The default is 1 for both.
+\item \code{beta_bernoulli_alpha} and \code{beta_bernoulli_alpha} the parameters of the "Beta-Bernoulli" or "Stochastic Block" priors. The default is 1 for both.
+
+\item \code{dirichlet_alpha} The shape of the Dirichlet prior on the node-to-block
+allocation parameters for the Stochastic Block prior on the graph structure.
 
 \item \code{threshold_alpha} and \code{threshold_beta} the parameters of the beta-prime distribution for the threshold parameters. The defaults are both set to 1.
+
+\item \code{variable_type} What kind of variables are there in \code{x}? Can be a
+single character string specifying the variable type of all \code{p}
+variables at once or a vector of character strings of length \code{p}
+specifying the type for each variable in \code{x} separately. Currently, bgm
+supports \verb{ordinal'' and }blume-capel''. Binary variables are automatically
+treated as ``ordinal’’. Defaults to \code{variable_type = "ordinal"}.
+
+\item \code{reference_category} he reference category in the Blume-Capel model.
+Should be an integer within the range of integer scores observed for the
+'blume-capel' variable. Can be a single number specifying the reference
+category for all Blume-Capel variables at once, or a vector of length
+\code{p} where the \code{i}-th element contains the reference category for
+variable \code{i} if it is Blume-Capel, and bgm ignores its elements for
+other variable types. The value of the reference category is also recoded
+when bgm recodes the corresponding observations. Only required if there is at
+least one variable of type ``blume-capel''.
 
 }
 

--- a/man/sparse_or_dense.Rd
+++ b/man/sparse_or_dense.Rd
@@ -43,7 +43,6 @@ that it is sparse and that it is dense, and computes th Bayes factor.
 }
 \examples{
 \donttest{
-
 library(easybgm)
 library(bgms)
 
@@ -51,7 +50,7 @@ data <- na.omit(Wenchuan)
 
 # Fitting the Wenchuan PTSD data
 
-fit <- sparse_or_dense(data, type = "binary",
+fit <- sparse_or_dense(data, type = "ordinal",
                 iter = 1000 # for demonstration only (> 5e4 recommended)
                 )
 }  


### PR DESCRIPTION
I made the following changes:

- Simplified the way the inclusion probability is calculated under the BB (and SBM) prior, which avoids unnecessary miscalculations that then affect the calculation of the BFs,

- Updated the package documentation to be more consistent with the new version of bgms.