### PR TITLE
Fix docs: df.prior in BDgraph value mismatch in code and doc

### DIFF
--- a/R/easybgm.R
+++ b/R/easybgm.R
@@ -100,7 +100,7 @@
 #'
 #' \itemize{
 #'
-#' \item \code{df.prior} prior on the parameters (i.e., inverse covariance matrix), degrees of freedom of the prior G-Wishart distribution. The default is set to 2.5.
+#' \item \code{df.prior} prior on the parameters (i.e., inverse covariance matrix), degrees of freedom of the prior G-Wishart distribution. The default is set to 3.
 #'
 #' \item \code{g.prior} prior probability of edge inclusion. This can be either a scalar, if it is the same for all edges, or a matrix, if it should be different among the edges. The default is set to 0.5.
 #'

--- a/man/easybgm.Rd
+++ b/man/easybgm.Rd
@@ -124,7 +124,7 @@ least one variable of type ``blume-capel''.
 
 \itemize{
 
-\item \code{df.prior} prior on the parameters (i.e., inverse covariance matrix), degrees of freedom of the prior G-Wishart distribution. The default is set to 2.5.
+\item \code{df.prior} prior on the parameters (i.e., inverse covariance matrix), degrees of freedom of the prior G-Wishart distribution. The default is set to 3.
 
 \item \code{g.prior} prior probability of edge inclusion. This can be either a scalar, if it is the same for all edges, or a matrix, if it should be different among the edges. The default is set to 0.5.
 


### PR DESCRIPTION
In BDgraph the degrees of freedom of the prior G-Wishart distribution (df.prior) must be >= 3. It is so in the easybbgm code. In the docs and man it stated that the default value is 2.5.
I hope this helps.
Cheerio and thanks for your work, Michael